### PR TITLE
fix golang download

### DIFF
--- a/SCRIPTS/02_prepare_package.sh
+++ b/SCRIPTS/02_prepare_package.sh
@@ -92,6 +92,7 @@ svn co https://github.com/openwrt/packages/trunk/devel/gcc feeds/packages/devel/
 #更换Golang版本
 rm -rf ./feeds/packages/lang/golang
 svn co https://github.com/openwrt/packages/trunk/lang/golang feeds/packages/lang/golang
+rm -rf ./feeds/packages/lang/golang/.svn
 rm -rf ./feeds/packages/lang/golang/golang
 svn co https://github.com/project-openwrt/packages/trunk/lang/golang/golang feeds/packages/lang/golang/golang
 #beardropper


### PR DESCRIPTION
需要提前删除svn缓存,不然svn会报already a working copy for a different URL  导致实际下载失败