### PR TITLE
Add LuCI-FileTransfer, -uhttpd, -statistics, -ttyd

### DIFF
--- a/.github/workflows/R2S-OpenWrt-Without-Docker.yml
+++ b/.github/workflows/R2S-OpenWrt-Without-Docker.yml
@@ -1,9 +1,6 @@
 name: R2S-OpenWrt-Without-Docker
 
 on:
-  push:
-    paths:
-      - '.github/workflows/R2S-OpenWrt-Without-Docker.yml'
   schedule:
     - cron: 5 9 * * *
   watch:
@@ -116,7 +113,7 @@ jobs:
       id: create_release
       uses: actions/create-release@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.workflow_token }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
       with:
         tag_name: ${{ steps.assemble_artifact.outputs.release_tag }}
         release_name: 自动发布 ${{ steps.assemble_artifact.outputs.release_tag }}
@@ -127,7 +124,7 @@ jobs:
       id: upload-release-asset
       uses: actions/upload-release-asset@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.workflow_token }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
         asset_path: ./artifact.zip

--- a/.github/workflows/R2S-OpenWrt-Without-Docker.yml
+++ b/.github/workflows/R2S-OpenWrt-Without-Docker.yml
@@ -30,7 +30,7 @@ jobs:
         sudo -E apt-get clean -y
         sudo -E rm -rf /usr/share/dotnet /etc/mysql /etc/php
         git clone https://github.com/friendlyarm/repo
-        sudo cp repo/repo  /usr/bin/
+        sudo cp repo/repo /usr/bin/
     - name: Free Disk Space
       run: |
         sudo swapoff -a

--- a/.github/workflows/R2S-OpenWrt-Without-Docker.yml
+++ b/.github/workflows/R2S-OpenWrt-Without-Docker.yml
@@ -30,7 +30,7 @@ jobs:
         sudo -E apt-get clean -y
         sudo -E rm -rf /usr/share/dotnet /etc/mysql /etc/php
         git clone https://github.com/friendlyarm/repo
-        sudo cp repo/repo /usr/bin/
+        sudo cp repo/repo  /usr/bin/
     - name: Free Disk Space
       run: |
         sudo swapoff -a

--- a/.github/workflows/R2S-OpenWrt-Without-Docker.yml
+++ b/.github/workflows/R2S-OpenWrt-Without-Docker.yml
@@ -1,6 +1,9 @@
 name: R2S-OpenWrt-Without-Docker
 
 on:
+  push:
+    paths:
+      - '.github/workflows/R2S-OpenWrt-Without-Docker.yml'
   schedule:
     - cron: 5 9 * * *
   watch:

--- a/SCRIPTS/02_prepare_package.sh
+++ b/SCRIPTS/02_prepare_package.sh
@@ -117,6 +117,8 @@ svn co https://github.com/coolsnowwolf/lede/trunk/package/lean/luci-app-arpbind 
 #Adbyby
 svn co https://github.com/coolsnowwolf/lede/trunk/package/lean/luci-app-adbyby-plus package/lean/luci-app-adbyby-plus
 svn co https://github.com/coolsnowwolf/lede/trunk/package/lean/adbyby package/lean/coremark/adbyby
+# File Transfer
+svn co https://github.com/coolsnowwolf/lede/trunk/package/lean/luci-app-filetransfer  package/lean/luci-app-filetransfer
 #访问控制
 svn co https://github.com/coolsnowwolf/lede/trunk/package/lean/luci-app-accesscontrol package/lean/luci-app-accesscontrol
 #AutoCore

--- a/SCRIPTS/02_prepare_package.sh
+++ b/SCRIPTS/02_prepare_package.sh
@@ -119,6 +119,7 @@ svn co https://github.com/coolsnowwolf/lede/trunk/package/lean/luci-app-adbyby-p
 svn co https://github.com/coolsnowwolf/lede/trunk/package/lean/adbyby package/lean/coremark/adbyby
 # File Transfer
 svn co https://github.com/coolsnowwolf/lede/trunk/package/lean/luci-app-filetransfer  package/lean/luci-app-filetransfer
+svn co https://github.com/coolsnowwolf/lede/trunk/package/lean/luci-lib-fs package/lean/luci-lib-fs
 #访问控制
 svn co https://github.com/coolsnowwolf/lede/trunk/package/lean/luci-app-accesscontrol package/lean/luci-app-accesscontrol
 #AutoCore

--- a/SEED/config_docker.seed
+++ b/SEED/config_docker.seed
@@ -160,6 +160,12 @@ CONFIG_PACKAGE_luci-app-frpc=y
 CONFIG_PACKAGE_zerotier=y
 CONFIG_PACKAGE_luci-app-zerotier=y
 
+CONFIG_PACKAGE_luci-app-uhttpd=y
+CONFIG_PACKAGE_luci-app-ttyd=y
+CONFIG_PACKAGE_luci-app-filetransfer=y
+CONFIG_PACKAGE_luci-app-statistics=y
+CONFIG_PACKAGE_collectd-mod-thermal=y
+
 CONFIG_PACKAGE_libcurl=y
 # CONFIG_LIBCURL_MBEDTLS is not set
 # CONFIG_LIBCURL_WOLFSSL is not set

--- a/SEED/config_no_docker.seed
+++ b/SEED/config_no_docker.seed
@@ -150,6 +150,12 @@ CONFIG_PACKAGE_luci-app-frpc=y
 CONFIG_PACKAGE_zerotier=y
 CONFIG_PACKAGE_luci-app-zerotier=y
 
+CONFIG_PACKAGE_luci-app-uhttpd=y
+CONFIG_PACKAGE_luci-app-ttyd=y
+CONFIG_PACKAGE_luci-app-filetransfer=y
+CONFIG_PACKAGE_luci-app-statistics=y
+CONFIG_PACKAGE_collectd-mod-thermal=y
+
 CONFIG_PACKAGE_libcurl=y
 # CONFIG_LIBCURL_MBEDTLS is not set
 # CONFIG_LIBCURL_WOLFSSL is not set


### PR DESCRIPTION
**You can omit the change of .github/workflows/R2S-OpenWrt-Without-Docker.yml**
Add luci-app-filetransfer, luci-lib-fs, luci-app-uhttpd, luci-app-ttyd, luci-app-statistics, collectd-mod-thermal.
The code can be compiled successfully on Github or self-owned PC. The changes have been verified on R2S.

Another suggestion is patch OC to 1.6GHz but by default turbo frequency set  up to 1.2GHz for safety.