### PR TITLE
Update 991-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-NanoPi4.patch

### DIFF
--- a/PATCH/new/main/991-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-NanoPi4.patch
+++ b/PATCH/new/main/991-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-NanoPi4.patch
@@ -105,7 +105,7 @@ Co-authored-by: gzelvis <gzelvis@gmail.com>
 +		};
 +		opp09 {
 +			opp-hz = /bits/ 64 <2208000000>;
-+			opp-microvolt = <1275000>;
++			opp-microvolt = <1300000>;
 +		};
 +	};
 +


### PR DESCRIPTION
提高OC稳定性,1g版本压测通过