### PR TITLE
Update 991-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-NanoPi4.patch

### DIFF
--- a/PATCH/new/main/991-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-NanoPi4.patch
+++ b/PATCH/new/main/991-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-NanoPi4.patch
@@ -105,7 +105,7 @@ Co-authored-by: gzelvis <gzelvis@gmail.com>
 +		};
 +		opp09 {
 +			opp-hz = /bits/ 64 <2208000000>;
-+			opp-microvolt = <1325000>;
++			opp-microvolt = <1300000>;
 +		};
 +	};
 +


### PR DESCRIPTION
经过反复测试, 用18W的紫米PD头(5V3A)可以稳定跑1300-1250/1275-1225 即是openssl进程出现异常,wan/lan灯不闪,页面卡住等问题,也不会死机或重启, ctrl+c停止进程后即可恢复;
如果换成1325-1250/1275-1225则会因为功耗超出18W导致断电
基于以上测试结果, 电压稳定在1300-1250/1275-1225即可, 稳定性和功耗相对均衡.