### PR TITLE
修正 ssrp 依赖

### DIFF
--- a/SCRIPTS/02_prepare_package.sh
+++ b/SCRIPTS/02_prepare_package.sh
@@ -186,9 +186,9 @@ svn co https://github.com/coolsnowwolf/lede/trunk/package/lean/ipt2socks package
 svn co https://github.com/coolsnowwolf/lede/trunk/package/lean/simple-obfs package/lean/simple-obfs
 svn co https://github.com/coolsnowwolf/packages/trunk/net/shadowsocks-libev package/lean/shadowsocks-libev
 svn co https://github.com/coolsnowwolf/lede/trunk/package/lean/trojan package/lean/trojan
-svn co https://github.com/immortalwrt/immortalwrt/branches/master/package/lean/tcpping package/lean/tcpping
+svn co https://github.com/xiaorouji/openwrt-passwall/trunk/tcping package/lean/tcping
 svn co https://github.com/fw876/helloworld/trunk/naiveproxy package/lean/naiveproxy
-svn co https://github.com/fw876/helloworld/trunk/ipt2socks-alt package/lean/ipt2socks-alt
+
 #PASSWALL
 svn co https://github.com/xiaorouji/openwrt-passwall/trunk/luci-app-passwall package/new/luci-app-passwall
 sed -i 's,default n,default y,g' package/new/luci-app-passwall/Makefile


### PR DESCRIPTION
ipt2socks-alt 已经没有了，依赖的是 tcping 不是 tcpping
#SSRP依赖 里面的 tcping 其实可以不加 他和 passwall 公用就行了。
