### PR TITLE
Add USB3.0 Support for R2S

### DIFF
--- a/SEED/R2S/config.seed
+++ b/SEED/R2S/config.seed
@@ -42,6 +42,9 @@ CONFIG_PACKAGE_kmod-ipt-nat6=y
 CONFIG_PACKAGE_kmod-tun=y
 CONFIG_PACKAGE_kmod-shortcut-fe=y
 CONFIG_PACKAGE_kmod-fast-classifier=y
+CONFIG_PACKAGE_kmod-usb2=y
+CONFIG_PACKAGE_kmod-usb2-pci=y
+CONFIG_PACKAGE_kmod-usb3=y
 # CONFIG_PACKAGE_kmod-shortcut-fe-cm is not set
 CONFIG_PACKAGE_libiwinfo=y
 CONFIG_PACKAGE_libiwinfo-lua=y


### PR DESCRIPTION
我用中文来说吧。众所周知，r2s的一个网口是usb3转接的，而大多数固件只打了usb2的驱动。